### PR TITLE
Update octoutm-index.html

### DIFF
--- a/octoutm-index.html
+++ b/octoutm-index.html
@@ -353,11 +353,12 @@
                 <label for="source">Traffic Source <span class="required">*</span></label>
                 <div class="preset-buttons">
                     <button type="button" class="preset-btn" data-field="source" data-value="google">Google</button>
-                    <button type="button" class="preset-btn" data-field="source" data-value="facebook">Facebook</button>
+                    <button type="button" class="preset-btn" data-field="source" data-value="tiktok">TikTok</button>
                     <button type="button" class="preset-btn" data-field="source" data-value="instagram">Instagram</button>
-                    <button type="button" class="preset-btn" data-field="source" data-value="twitter">Twitter</button>
-                    <button type="button" class="preset-btn" data-field="source" data-value="linkedin">LinkedIn</button>
                     <button type="button" class="preset-btn" data-field="source" data-value="email">Email</button>
+                    <button type="button" class="preset-btn" data-field="source" data-value="telegram">Telegram</button>
+                    <button type="button" class="preset-btn" data-field="source" data-value="facebook">Facebook</button>
+                    <button type="button" class="preset-btn" data-field="source" data-value="twitter">Twitter</button>
                 </div>
                 <input type="text" id="source" placeholder="e.g., google, facebook, newsletter" required>
                 <div class="help-text">Where is the traffic coming from? (use lowercase, no spaces)</div>


### PR DESCRIPTION
Updated Source Buttons:

Google - for Google Ads/search
TikTok - for TikTok content
Instagram - for Instagram posts
Email - for email campaigns
Telegram - for Telegram channels/messages
Facebook - for Facebook posts/ads
Twitter - for Twitter/X posts
(Removed LinkedIn as requested)

Updated Medium Buttons:

Paid Search → utm_medium=cpc
Social Media → utm_medium=social
Reels → utm_medium=reels (specific medium for Instagram/Facebook Reels) Story → utm_medium=story (specific medium for Instagram/Facebook Stories) Video → utm_medium=video (perfect for TikTok video content) Email → utm_medium=email
Display Ads → utm_medium=display

(Removed Referral completely as requested)

Perfect Combinations Now Available:
TikTok Video:
Source: tiktok + Medium: video

Instagram Reels:
Source: instagram + Medium: reels
Instagram Story:
Source: instagram + Medium: story
Telegram Message:
Source: telegram + Medium: social or email